### PR TITLE
Render input "value" as HTML attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock
 
 # Runtime data
 pids

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,14 @@ function createRenderer(renderer, tagName, componentAPI, props = {}) {
   const cleanup = jsDOMGlobal()
   const root = document.createElement(tagName)
   const element = component(componentAPI)(root, props)
+
+  //reflect input value prop to attribute
+  element.$$('input,textarea').map((el) => {
+    if(el.value) {
+      el.setAttribute('value', el.value)
+    }
+  })
+
   const result = renderer({
     // serialize the component outer html
     html: root.outerHTML,

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,8 @@ function createRenderer(renderer, tagName, componentAPI, props = {}) {
 
   //reflect input value prop to attribute
   element.$$('input,textarea,select,option').map((el) => {
-    if(el.value) {
-      el.setAttribute('value', el.value)
-    }
+    const value = el.type !== 'password' ? el.value : ''
+    el.setAttribute('value', value || '')
   })
 
   const result = renderer({

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ function createRenderer(renderer, tagName, componentAPI, props = {}) {
   const element = component(componentAPI)(root, props)
 
   //reflect input value prop to attribute
-  element.$$('input,textarea').map((el) => {
+  element.$$('input,textarea,select,option').map((el) => {
     if(el.value) {
       el.setAttribute('value', el.value)
     }

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -50,5 +50,12 @@ describe('ssr', () => {
     expect(result).to.match(/type="radio"(.*)checked/)
   })
 
+  it('omits password inputs', function(){
+    const InputComponent = require('./tags/password-input.riot').default
+    const result = render('div', InputComponent)
+    expect(result).to.match(/input value=""/)
+    expect(result).to.match(/type="password"(.*)value=""/)
+  })
+
 
 })

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -46,6 +46,8 @@ describe('ssr', () => {
     const InputComponent = require('./tags/simple-input.riot').default
     const result = render('div', InputComponent)
     expect(result).to.match(/value="test"/)
+    expect(result).to.match(/type="checkbox"(.*)checked/)
+    expect(result).to.match(/type="radio"(.*)checked/)
   })
 
 

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -41,4 +41,12 @@ describe('ssr', () => {
     expect(html).to.match(/<p>hello/)
     expect(css).to.match(/red/)
   })
+
+  it('can render inputs', function(){
+    const InputComponent = require('./tags/simple-input.riot').default
+    const result = render('div', InputComponent)
+    expect(result).to.match(/value="test"/)
+  })
+
+
 })

--- a/test/tags/password-input.riot
+++ b/test/tags/password-input.riot
@@ -1,0 +1,11 @@
+<simple-input>
+  <input />
+  <input type="password" value={state.val} />
+  <script>
+    export default {
+      state: {
+        val: 'test'
+      }
+    }
+  </script>
+</simple-input>

--- a/test/tags/simple-input.riot
+++ b/test/tags/simple-input.riot
@@ -1,0 +1,10 @@
+<simple-input>
+  <input value={state.val} />
+  <script>
+    export default {
+      state: {
+        val: 'test'
+      }
+    }
+  </script>
+</simple-input>

--- a/test/tags/simple-input.riot
+++ b/test/tags/simple-input.riot
@@ -1,9 +1,12 @@
 <simple-input>
   <input value={state.val} />
+  <input type="checkbox" checked={state.checked} />
+  <input type="radio" checked={state.checked} />
   <script>
     export default {
       state: {
-        val: 'test'
+        val: 'test',
+        checked: true
       }
     }
   </script>


### PR DESCRIPTION
When the input value is set through a property using javascript (`input.value = "test"`) it does not reflect on the HTML attribute "value". So the markup rendered by javascript would return no values for `<input>` elements. 