### PR TITLE
feature: add options to register module

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -3,7 +3,7 @@ import {compile} from '@riotjs/compiler'
 import {transform} from '@babel/core'
 
 // returns the teardown function
-export default () => addHook(
+export default (options) => addHook(
   function(source, filename) {
     const {code} = compile(source, { file: filename })
 
@@ -21,5 +21,5 @@ export default () => addHook(
       ]
     }).code
   },
-  { exts: ['.riot'], ignoreNodeModules: false }
+  Object.assign({ exts: ['.riot'], ignoreNodeModules: false }, options)
 )

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -8,7 +8,7 @@ describe('ssr', () => {
   let unregister // eslint-disable-line
 
   before(() => {
-    unregister = register()
+    unregister = register({ exts: ['.riot', '.tag'] })
   })
 
   after(() => {
@@ -57,5 +57,10 @@ describe('ssr', () => {
     expect(result).to.match(/type="password"(.*)value=""/)
   })
 
+  it('can require and render legacy .tag file', function(){
+    const LegacyComponent = require('./tags/legacy.tag').default
+    const result = render('div', LegacyComponent, {message:'tag file rendered successfully'})
+    expect(result).to.match(/tag file rendered successfully/)
+  })
 
 })

--- a/test/tags/legacy.tag
+++ b/test/tags/legacy.tag
@@ -1,0 +1,3 @@
+<legacy>
+    <span>{ props.message }</span>
+</legacy>


### PR DESCRIPTION
This provides a way to require `.tag` files when using SSR

Fixes https://github.com/riot/ssr/issues/4