### PR TITLE
fixed: missing CSS of sub-components when rendering asynchronously

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,10 @@ export const renderAsync = curry(createRenderer)(
   renderComponentAsync(rendererPayload => getOnlyHTMLFromRenderer(rendererPayload, true))
 )
 export const renderAsyncFragments = curry(createRenderer)(
-  renderComponentAsync(rendererPayload => getFragmentsFromRenderer(rendererPayload, true))
+  renderComponentAsync(rendererPayload => {
+    rendererPayload.css = [...CSS_BY_NAME.values()].join('\n')
+    return getFragmentsFromRenderer(rendererPayload, true)
+  })
 )
 export const fragments = curry(createRenderer)(getFragmentsFromRenderer)
 export const render = curry(createRenderer)(getOnlyHTMLFromRenderer)


### PR DESCRIPTION
Currently when rendering asynchronously, only the CSS of the main component and of the sub-components statically included in the main component are rendered.

To demonstrate this I extended the **ssr** example to include a bit of CSS specific to each page and delayed the hydration, see [PR#190](https://github.com/riot/examples/pull/190) in `riot/examples`: until hydration takes place the page-local CSS is not applied.

I spent some time poking around the code and I eventually found a simple fix for this, even it it does not feel very elegant (because of the overwrite): CSS for all involved components will only be available once the initial asynchronous render completed (as opposed to the moment when the main component was created, in the current version). Re-generating the CSS _after_ that render made the modified **ssr** example above work as expected.

I could not see any risk introduced by the change, since it just replaces the initial CSS with _more_ CSS.